### PR TITLE
Extend hypdbgrs utility's target option

### DIFF
--- a/utils/hypdbgrs/Makefile
+++ b/utils/hypdbgrs/Makefile
@@ -1,5 +1,6 @@
 all:
 	cargo build --target=aarch64-unknown-linux-gnu
+	cp target/aarch64-unknown-linux-gnu/debug/hypdbgrs .
 
 clean:
 	cargo clean


### PR DESCRIPTION
Parser for the target option now allows to specify several guests. "guest" and "guest1" are considered as the same and will be translated to target id == 2. General format for the guest target is "guest[nr]" where nr will be incremented and interpreted as target id e.g.

guest4 -> target id == 5
guest13 -> target id == 14

Also, for the count-shared subcommand a check was added: if an intension would be to count shared pages between host and host program execution will be aborted