### PR TITLE
 Added support for g2g share build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include core/vars.mk
 
 DIRS := tools qemu-user host-kernel ubuntu-template target-crosvm hostimage guest-kernel guestimage
+TMPDIR := $(shell mktemp -d -u)
 
 all: $(DIRS)
 
@@ -70,6 +71,14 @@ pkvm-debug-tools-clean:
 host-initramfs:
 	$(MAKE) -C pkvm-debug-tools initramfs KERNEL_DIR=$(HOST_KERNEL_DIR) UBUNTU_DIR=$(BASE_DIR)/oss/ubuntu-template
 	$(MAKE) -C pkvm-debug-tools install OUT_IMAGE=$(BASE_DIR)/images/host/initramfs.gz
+
+host-modules-install:
+	@mkdir $(TMPDIR)
+	@sudo ./scripts/qmount.py ./images/host/ubuntuhost.qcow2 $(TMPDIR)
+	@sudo make -C $(HOST_KERNEL_DIR)  INSTALL_MOD_PATH=$(TMPDIR) modules_install
+	@sync
+	@sudo ./scripts/qumount.py $(TMPDIR)
+	@rm -r $(TMPDIR)
 
 ubuntu-template:
 	@./scripts/ubuntu-template.sh

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -1,7 +1,7 @@
-ROGNAME := hyp
+PROGNAME := hyp
 
 PROG := $(OBJDIR)/$(PLATFORM)/$(PROGNAME)
-LIBNAME := lib$(PLATFORM).a
+
 QEMU := qemu-system-aarch64
 QEMU_DTFILE := qemu_devtree
 
@@ -14,18 +14,18 @@ PVMFW_ADDRESS := 0x40001000
 INITRAMFS := $(HOST_IMAGE_DIR)/initramfs.gz
 INITRAMFS_ADDR := 0x7f000000
 
+#amount of memory allocated for sharing between guests
+G2G_SHARE_SIZE := 0x2000000
+
 KERNEL_PKVM_PARAMS := kvm-arm.mode=protected kvm-arm.protected_modules=pkvm-dbg-tools
 
 VMLINUX := $(KERNEL_DIR)/vmlinux
 WAYOUT := $(shell exec ip route get 1.1.1.1 | grep -oP 'src \K\S+')
 PORT := 10022
-#DRIVE := -drive file=$(IMAGE),format=qcow2,if=sd,id=ubu-sd -device virtio-blk-device,drive=ubu-sd
 DRIVE := -drive file=$(IMAGE),if=none,format=qcow2,id=hd0 -device virtio-blk-device,drive=hd0
 BOOTIMG := $(DRIVE)
 USB := -device qemu-xhci -device usb-kbd -device usb-tablet
 NETWORK := -device e1000,netdev=net0 -netdev user,id=net0,host=192.168.7.1,net=192.168.7.0/24,restrict=off,hostname=guest,hostfwd=tcp:$(WAYOUT):$(PORT)-192.168.7.2:22
-COMP_IMG ?= $(OBJDIR)/$(PLATFORM)/hyp-loader
-USE_COMP_IMG ?= 0
 
 KERNEL_OPTS :=  $(KERNEL_PKVM_PARAMS) root=/dev/vda1 console=ttyAMA0 mem=8G nokaslr loglevel=8 rw
 
@@ -38,29 +38,15 @@ QEMUDEBUGOPTS := guest_errors,unimp,mmu
 else
 QEMUDEBUGOPTS := guest_errors,unimp
 endif
+
 QEMUDEBUGLOG := -D $(BASE_DIR)/qemudebug.log
-
-LINK := -T ld.out -Ttext=0xC0001000
-LDFLAGS := $(LDFLAGS) $(LINK)
-
-AS_SOURCES := reset.S
-C_SOURCES := host_platform.c
-
-ifeq ($(USE_COMP_IMG),1)
-HYP_IMAGE := -device loader,file=$(COMP_IMG).bin,addr=0xC0080000,force-raw=true
-else
-HYP_IMAGE := -device loader,file=$(PROG).bin,addr=0xC0000000,force-raw=true
-endif
-
 QEMUOPTS := --accel tcg,thread=multi -d $(QEMUDEBUGOPTS) $(QEMUDEBUGLOG) $(DEBUGOPTS) \
 	    -machine virt,virtualization=on,secure=off,gic-version=3 \
 	    -cpu max,sve=off,lpa2=off -smp 4 -m 8G $(NETWORK) $(USB) $(BOOTIMG) \
 	    -kernel $(KERNEL) -append '$(KERNEL_OPTS)'
 
-ifneq (,$(filter 1, $(USE_KIC) $(USE_INITRAMFS)))
+ifneq (,$(filter 1, $(USE_KIC) $(USE_INITRAMFS) $(USE_G2GSHARE)))
 EXTRAOPTS :=  -dtb $(QEMU_DTFILE).dtb
-TMPFILE := $(shell mktemp)
-
 endif
 
 ifeq ($(USE_KIC),1)
@@ -106,6 +92,9 @@ ifeq ($(USE_INITRAMFS),1)
 else
 		@echo Dont use initramfs
 endif
+ifeq ($(USE_G2G_SHARE),1)
+		@echo "Initiate guest to guest share buffer "
+endif
 	@echo "Host ssh login is available via $(WAYOUT):$(PORT)"
 	@echo "------------------------------------------------------------------------------------------"
 	@rm -f $(SPICESOCK)
@@ -118,14 +107,22 @@ generate-dtb:
 	@$(QEMUCMD-DTB)
 	@dtc -O dts -o $(QEMU_DTFILE).dts -I dtb $(QEMU_DTFILE).dtb
 ifeq ($(USE_KIC),1)
-	@cp $(QEMU_DTFILE).dts $(TMPFILE)
-	$(CURDIR)/fix-qemu-dts.py -i $(TMPFILE) -o $(QEMU_DTFILE).dts  -K \
-	-a $(PVMFW_ADDRESS) -s $(shell stat -c %s $(PVMFW_LOADER))
+	@echo 	$(CURDIR)/fix-qemu-dts.py -d $(QEMU_DTFILE).dts \
+	-a $(PVMFW_ADDRESS) -s $(shell stat -c %s $(PVMFW_LOADER)) KIC
+
+	$(CURDIR)/fix-qemu-dts.py -d $(QEMU_DTFILE).dts \
+	-a $(PVMFW_ADDRESS) -s $(shell stat -c %s $(PVMFW_LOADER)) KIC
 endif
 ifeq ($(USE_INITRAMFS),1)
-	@cp $(QEMU_DTFILE).dts $(TMPFILE)
-	@$(CURDIR)/fix-qemu-dts.py -i $(TMPFILE) -o $(QEMU_DTFILE).dts  -I \
-	-a $(INITRAMFS_ADDR) -s $(shell stat -c %s $(INITRAMFS))
+	@echo 	@$(CURDIR)/fix-qemu-dts.py -d $(QEMU_DTFILE).dts \
+	-a $(INITRAMFS_ADDR) -s $(shell stat -c %s $(INITRAMFS)) INITRD
+
+	@$(CURDIR)/fix-qemu-dts.py -d $(QEMU_DTFILE).dts \
+	-a $(INITRAMFS_ADDR) -s $(shell stat -c %s $(INITRAMFS)) INITRD
+endif
+ifeq ($(USE_G2G_SHARE),1)
+	@$(CURDIR)/fix-qemu-dts.py -d $(QEMU_DTFILE).dts \
+	-S $(G2G_SHARE_SIZE) G2G_SHARE
 endif
 	@dtc -I dts -o $(QEMU_DTFILE).dtb -O dtb $(QEMU_DTFILE).dts
 

--- a/scripts/qmount.py
+++ b/scripts/qmount.py
@@ -1,0 +1,71 @@
+#! /usr/bin/python3
+import subprocess
+import sys
+from sys import exit
+import glob
+import time
+import os
+
+def wait_for_dev(dev: str, secs: int = 5):
+    print("Waiting for {}...".format(dev))
+    s_time = time.time()
+    while True:
+        if time.time() - s_time > secs:
+            print("ERROR: {} secs timeout exceeded!".format(secs))
+            return False
+        if os.path.exists(dev):
+            break
+        else:
+            time.sleep(1)
+    return True
+
+
+def find_free_dev():
+    tmp = subprocess.run(["ls -1 /dev/nb*"],  shell=True, stdout=subprocess.PIPE)
+    mounts  = tmp.stdout.decode().splitlines()
+    s = []
+    for mnt in mounts:
+        if mnt.endswith("p1"):
+            x = mnt.partition("/dev/nbd")
+            s.append(x[2][0])
+
+    for i in range(0, 8):
+        if not str(i) in s:
+             return "/dev/nbd{}".format(i)
+    else:
+        return ""
+
+def usage():
+    print("Usage: qmount.sh <qcow2 file> <mount point> <mount option> ")
+
+if (len(sys.argv) < 3 or len(sys.argv) > 4):
+    usage()
+    exit(1)
+
+dev = find_free_dev()
+if not dev in glob.glob("/dev/nbd[0-8]"):
+    cmd =["modprobe", "nbd", "max_part=8"]
+    print(" ".join(cmd))
+    p = subprocess.run(cmd)
+    if p.returncode:
+        exit(1)
+
+if (len(dev) > 0):
+    cmd = ["qemu-nbd","--connect={}".format(dev), sys.argv[1]]
+    print(" ".join(cmd))
+    p = subprocess.run(cmd)
+    if p.returncode:
+        exit(1)
+
+    pdev = "{}p1".format(dev)
+    wait_for_dev(pdev)
+    if (len(sys.argv) == 4):
+        mparam = sys.argv[3]
+    else:
+         mparam = ""
+    cmd = "mount {} {}p1 {}".format(mparam,dev,sys.argv[2])
+    print(cmd)
+    if os.system(cmd):
+        cmd = "qemu-nbd --disconnect {}".format(dev)
+        print(cmd)
+        os.system(cmd)

--- a/scripts/qumount.py
+++ b/scripts/qumount.py
@@ -1,0 +1,38 @@
+#! /usr/bin/python3
+import subprocess
+import sys
+import os
+from sys import exit
+
+def find_dev(file):
+    if file.startswith("/dev/nbd"):
+        return file
+    file = file.rstrip("/")
+    tmp = subprocess.run(["mount","-t","ext4"], stdout=subprocess.PIPE)
+    mounts  = tmp.stdout.decode().splitlines()
+    s = []
+    for mnt in mounts:
+        if mnt.startswith("/dev/nbd"):
+            x = mnt.split()
+            if not file.startswith("/"):
+                file = os.getcwd() + "/" + file
+            if (file == x[2]):
+                return x[0]
+    else:
+        return ""
+
+def usage():
+    print("Usage: qumount.sh <mount point>")
+
+if (len(sys.argv) != 2):
+    usage()
+    exit(1)
+
+dev = find_dev(sys.argv[1])
+if (len(dev) > 0):
+        cmd = "qemu-nbd --disconnect {}".format(dev)
+        print(cmd)
+        os.system(cmd)
+        cmd = "umount {}".format(dev)
+        print(cmd)
+        os.system(cmd)


### PR DESCRIPTION
    Memory sharing between guests requires a suitable device tree file
    for the host.
    When the host is booted in qemu, the appropriate device tree is
    created when the make parameter is USE_G2GSHARE=1
    e.g.: make USE_G2GSHARE=1 run
